### PR TITLE
Add predictions for followers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@ models/pretrained_BERT/
 .ipynb_checkpoints/
 personality_env/
 twitter_data/
+geckodriver.log
+fbscraper.py
 .env
 .DS_Store

--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 
 from flask import Flask, render_template, request, redirect, url_for,jsonify
 from flask_cors import CORS
-from predict_types import predict_type,recreate_model, predict_tweet
+from predict_types import predict_type,recreate_model, predict_tweet, predict_follow
 from twitterscraper import tweet_return
 
 app = Flask(__name__)
@@ -32,6 +32,20 @@ def tweet():
         user_handle = data["handle"]
         tweet_return(user_handle)
         user_type = predict_tweet(user_handle)
+        return jsonify({"type":str(user_type)}),200
+
+@app.route('/follow_pred', methods=['GET', 'POST'])
+def follow_tweet():
+    # GET request
+    if request.method == 'GET':
+        message = {'greeting':'Hello from Flask!'}
+        return jsonify(message)  # serialize and use JSON headers
+    # POST request
+    if request.method == 'POST':
+        data = request.get_json()  # parse as JSON
+        user_handle = data["handle"]
+        # tweet_return(user_handle)
+        user_type = predict_follow(user_handle)
         return jsonify({"type":str(user_type)}),200
 
 if __name__ == '__main__' :

--- a/index.html
+++ b/index.html
@@ -18,6 +18,10 @@
     <button onClick="mytweet()", type="submit">Submit</button>
   </form>
 </div>
+<div>
+  <button onClick="myfollowers()", type="submit">Followers</button>
+</form>
+</div>
 </div>
 
 
@@ -67,7 +71,29 @@ function mytweet() {
             .then(data=>console.log(JSON.stringify(data)))
             .catch(error=>console.log(JSON.stringify(error)))
 }
-    
+
+function myfollowers() {
+        var text = document.getElementById('twitter_handle').value;
+        console.log(text);
+        const url = 'http://127.0.0.1:5000/follow_pred';
+        let send_data = JSON.stringify({
+            'handle': text
+        });
+        let fetchData = {
+            method: 'POST',
+            // mode: 'cors',
+            body: send_data,
+            headers:  {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+              }
+        }
+        console.log(fetchData);
+        fetch(url, fetchData)
+        .then(data=> data.json())
+            .then(data=>console.log(JSON.stringify(data)))
+            .catch(error=>console.log(JSON.stringify(error)))
+}
 
 
 </script>

--- a/predict_types.py
+++ b/predict_types.py
@@ -55,7 +55,21 @@ def predict_tweet(username):
     tweet_ind = tweet_vals.argmax(axis=1)
     return (per_types[stats.mode(tweet_ind).mode[0]])
 
-
+def predict_follow(username):
+    follow_df = pd.read_csv("twitter_data/fol_"+str(username)+".csv")
+    follow_json = {}
+    for i in range(5):
+        list_j = follow_df.tweets.iloc[i].split(", \'")
+        new_list = []
+        for j in list_j:
+            new_list.append(clean_text(j))
+        tweet_ids = [tokenizer.encode(str(k), max_length = 100 , pad_to_max_length = True) for k in new_list]
+        tweet_vals = new_model.predict(np.array(tweet_ids))
+        tweet_ind = tweet_vals.argmax(axis=1)
+        print (per_types[stats.mode(tweet_ind).mode[0]])
+        follow_json[str(i)] = per_types[stats.mode(tweet_ind).mode[0]]
+    return follow_json
+    
 
 # new_mod = recreate_model()
 # print (new_mod.summary())


### PR DESCRIPTION
Should solve #13 

### Changes made:

- made new function `get_user_followers` in twitterscraper.py to make new csv file of the form `fol_<username>.csv` containing 2 columns: 

`followers`  - follower_names
`tweets` - array of 10 tweets by the follower

- made a new function `predict_follow` in predict_types.py to read the csv and for each follower:

1. extract text messages as array
2. clean the array
3. pass it to the model
4. make predictions using model

- link a new js function `myfollowers()` in index.html to the Followers button on the index page
- myfollowers() calls the API endpoint `/follow_pred` which performs predictions for followers.

### How to Test:

Similar to Twitter predictions, just click on the Followers button. You should get response of the following form on the console:
`{"type":"{'0': 'ISFP', '1': 'ISFP', '2': 'INFP', '3': 'INFP', '4': 'INFP'}"}`

The personalities correspond to the index. In addition the personalities should display on the terminal as output.

NOTE: The individual user personality fetching may take a little longer than previously, but I think it's an acceptable delay.